### PR TITLE
Release 1.4.5.3 (#91)

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -4,8 +4,8 @@ pull_requests:
 skip_non_tags: false
 platform: x64
 image: 
-  - Ubuntu
   - Visual Studio 2017
+  - Ubuntu
 init:
   - cmd: git config --global core.autocrlf true
 install:
@@ -21,7 +21,7 @@ install:
 build_script:
   - ./gradlew build -x test
 after_build:
-  - ./gradlew deploy
+  - ps: if($env:APPVEYOR_REPO_TAG -eq 'True') { ./gradlew deploy } else { echo "Not creating deploy artifacts because this is not a tag build" }
 artifacts:
   - path: build\libs\MapTool-*.jar
     name: MapTool-Jar
@@ -31,54 +31,17 @@ artifacts:
     name: MapTool-Linux
 deploy:
   - provider: GitHub
-    description: Windows release from AppVeyor
-    auth_token:
-      secure: HXIHe/F7K2yGOZ0I56DW5PevrQDe+zjyunjORGKYaUGxFtvPYPcmOdjZT69tzHcS
+    description: Release build from AppVeyor
+    auth_token: $(GITHUB_RELEASE_KEY)
     artifact: MapTool-Jar, MapTool-Windows, MapTool-Linux
-    draft: true
+    draft: false
     prerelease: true
-    force_update: true
+    force_update: false
     on:
       APPVEYOR_REPO_TAG: true
-notifications:
-  - provider: Webhook
-    url: 
-      secure: AYQNchUXucpUxTDKoURYmnesdyYxxAPeGmGf0tM/aJhGVp8X5yuiKoZNjULxjoOICX47ufGpdz+BEJ9nYaj7WrBSNx5dJJOoxsZ+dpPZfPOlidHW/JoNWHM8JMP0P5TwRGaTOGOk3aIlUBftDA/wRVQhRcjiwivpoA0mzD6PSsY=
-    method: POST
-    body: >-
-      {
-        "embeds": [
-          {
-            "title": "Build {{buildId}}",
-            "url": "{{buildUrl}}",
-            "color": {{#passed}}40973{{/passed}}{{^passed}}11672839{{/passed}},
-            "footer": {
-              "icon_url": "{{#passed}}https://i.imgur.com/Rf4g8v6.png{{/passed}}{{^passed}}https://i.imgur.com/QaERwAW.png{{/passed}}",
-              "text": "{{#passed}}Success{{/passed}}{{^passed}}Failure{{/passed}}"
-            },
-            "author": {
-              "name": "{{commitAuthor}}",
-              "url": "https://github.com/{{repositoryName}}/commit/{{commitId}}"
-            },
-            "fields": [
-              {
-                "name": "Commit",
-                "value": "[{{commitMessage}}](https://github.com/{{repositoryName}}/commit/{{commitId}})"
-              },
-              {
-                "name": "Duration",
-                "value": "{{duration}}",
-                "inline": true
-              },
-              {
-                "name": "Build version",
-                "value": "{{buildVersion}}",
-                "inline": true
-              }
-            ]
-          }
-        ]
-      }
-    on_build_success: true
-    on_build_failure: true
-    on_build_status_changed: true
+on_success:
+  - ps: Invoke-RestMethod $env:APPVEYOR_DISCORD_WEBHOOK_SCRIPT_URL -o send.ps1
+  - ps: ./send.ps1 success $env:DISCORD_URL
+on_failure:
+  - ps: Invoke-RestMethod $env:APPVEYOR_DISCORD_WEBHOOK_SCRIPT_URL -o send.ps1
+  - ps: ./send.ps1 failure $env:DISCORD_URL

--- a/.gitignore
+++ b/.gitignore
@@ -42,5 +42,4 @@ workbench.xmi
 
 # Keystore
 build-resources/rptools-keystore
-/gradle.properties
 /releases/

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,34 +3,14 @@ sudo: false
 matrix:
   include:
   - os: osx
-    osx_image: xcode9.2
-    before_install:
-      - brew update
-      - brew cask reinstall java
-      - java -version
+    osx_image: xcode10
 script: 
   - ./gradlew build -x test
-after_success:
-  - wget https://raw.githubusercontent.com/k3rn31p4nic/travis-ci-discord-webhook/master/send.sh
-  - chmod +x send.sh
-  - ./send.sh success $DISCORD_URL
-after_failure:
-  - wget https://raw.githubusercontent.com/k3rn31p4nic/travis-ci-discord-webhook/master/send.sh
-  - chmod +x send.sh
-  - ./send.sh failure $DISCORD_URL
-before_cache:
-  - rm -f  $HOME/.gradle/caches/modules-2/modules-2.lock
-  - rm -fr $HOME/.gradle/caches/*/plugin-resolution/
-cache:
-  directories:
-  - "$HOME/.gradle/caches/"
-  - "$HOME/.gradle/wrapper/"
 before_deploy:
  - ./gradlew deploy
 deploy:
   provider: releases
-  api_key:
-    secure: kkJvHO3wHKCnGT2aKQs4zt4Z+HYEwOnpM7Gnnz+8PzXx8uCi/7+bDROC619lAKxFQAVNobj88kyHQ5mKqgdgYpz8Rdk8MfEMX+4m+FaqY2kDYzkCK2v9zrDohoe39W6my/nLpO9DJ/hel5J9o0oXfCmik6FqbTZG6EYgl3vY2II8X1GR8O07OgxpnPnft9LMXG08Kkc0Ni/LayFXjF8Pg0LcOY18o4jwSOXIKPUPYLomMIYEr8vGkZJ9AP8b6GsxyWXy4gUQRjVNcb0QzbPX6PxhR+elCeg/1VR4w8WVAdfCJPzoIibzHitQfdALekgvwMe8Z7RrwiCYc9e89mLAL/PM9o/2qCuHiY2CJYUW1q8qc5MiXWaxLXTi4uC4IFB8eNXqU9LZUlCXUo0IZyujMhR23WxaK0nWYYntmLgVh7/PNie/ooDIXK54AOzsSpyWw0mfgJ99GgdyiUKsEH3UqmqIpXgnOmSbzK5s511Ag3/swJQuMU0DqZemKrRAShTdLhGED2e/6JTtLVpMbpfs7KvAqIk6hFQ+L1IKfyBWRab7V2gF1sutxTpicwaTusDF20hdGsHycxN1jPuxhduqkQ/LIjRt8pyAkWGEy/ARmGuXpY8jpbbXGyvNnqh70r/wJaFsN6NQ34VFSl2yMxw9DrKOSmGvtPNpK82X0bILI3A=
+  api_key: $GITHUB_RELEASE_KEY
   file_glob: true
   file: releases/release-*/*
   overwrite: true
@@ -39,6 +19,16 @@ deploy:
   tag_name: $TRAVIS_TAG
   draft: true
   on:
-    repo: JamzTheMan/MapTool
+    repo: $REPO
     tags: true
     all_branches: true
+notifications:
+  webhooks:
+    on_success:
+      - wget $TRAVIS_DISCORD_WEBHOOK_SCRIPT_URL
+      - chmod +x send.sh
+      - ./send.sh success $DISCORD_URL
+    on_failure:
+      - wget $TRAVIS_DISCORD_WEBHOOK_SCRIPT_URL
+      - chmod +x send.sh
+      - ./send.sh failure $DISCORD_URL

--- a/build-resources/sentry.properties.template
+++ b/build-resources/sentry.properties.template
@@ -1,0 +1,4 @@
+dsn=${SentryDSN}
+environment=${Environment}
+stacktrace.app.packages=net.rptools.lib,net.rptools.maptool
+release=${AppVersion}

--- a/build.gradle
+++ b/build.gradle
@@ -16,7 +16,7 @@ buildscript {
 
 // Access Git info from build script
 plugins {
-	id "org.ajoberstar.grgit" version "2.2.0"
+	id "org.ajoberstar.grgit" version "2.3.0"
 }
 
 // Apply the java plugin to add support for Java
@@ -25,9 +25,6 @@ apply plugin: 'application'
 apply plugin: 'java'
 apply plugin: 'eclipse'
 apply plugin: 'com.diffplug.gradle.spotless'
-
-// Current Build version
-version = '1.4.5.2'
 
 // Definitions
 defaultTasks 'clean', 'build'
@@ -43,14 +40,33 @@ applicationDefaultJvmArgs = ["-Xss4M"]
 
 // Custom properties
 ext {
-	vendor = "Nerps" // Change to RPTools for official builds
-	git = org.ajoberstar.grgit.Grgit.open(currentDir: file('.'))
-	revision = git.head().abbreviatedId
-	revisionFull = git.head().id
-	// branch = grgit.branch.current().name
 	gdxVersion = '1.9.6'
 	box2DLightsVersion = '1.4'
 	aiVersion = '1.8.1'
+
+	// Get tag and commit info from Git to use for version numbering
+	def repo = org.ajoberstar.grgit.Grgit.open(currentDir: file('.'))
+	def head = repo.head()
+	def tags = repo.tag.list().find {
+		it.commit == head
+	}
+
+	revision = head.abbreviatedId
+	revisionFull = head.id
+
+	if (tags) {
+		tagVersion = tags.getName()
+		msiVersion = tagVersion
+		enviroment = "Production"
+		sentryDSN = sentry_production_dsn
+	} else {
+		tagVersion = 'SNAPSHOT-' + revision
+		enviroment = "Development"
+		sentryDSN = sentry_development_dsn
+	}
+
+	// vendor, tagVersion, msiVersion, and DSN's defaults are set in gradle.properties
+	println 'Configuring for ' + project.name + " " + tagVersion + " by " + vendor
 }
 
 run {
@@ -120,26 +136,18 @@ repositories {
 
 // In this section you declare the dependencies for your production and test code
 dependencies {
-	// For UserJvmOptionsService; native to os...
-	// compile files("${System.properties['java.home']}/../lib/packager.jar")
-
 	// For Sentry bug reporting
-	compile group: 'org.apache.logging.log4j', name: 'log4j-api', version: '2.8.2'
-	compile group: 'org.apache.logging.log4j', name: 'log4j-core', version: '2.8.2'
-	compile group: 'org.apache.logging.log4j', name: 'log4j-1.2-api', version: '2.8.2'	// Bridges v1 to v2 for other code in other libs
+	annotationProcessor group: 'org.apache.logging.log4j', name: 'log4j-core', version: '2.11.0'
+	compile group: 'org.apache.logging.log4j', name: 'log4j-api', version: '2.11.0'
+	compile group: 'org.apache.logging.log4j', name: 'log4j-1.2-api', version: '2.11.0'	// Bridges v1 to v2 for other code in other libs
 
 	compile group: 'org.slf4j', name: 'slf4j-simple', version: '1.7.25'
 	compile group: 'commons-logging', name: 'commons-logging', version: '1.2'
 
-	compile 'io.sentry:sentry:1.5.0'
-	compile 'io.sentry:sentry-log4j2:1.5.2'
+	compile group: 'io.sentry', name: 'sentry', version: '1.7.5'
+	compile group: 'io.sentry', name: 'sentry-log4j2', version: '1.7.5'
 
 	compile group: 'org.apache.commons', name: 'commons-collections4', version: '4.1' // https://mvnrepository.com/artifact/org.apache.commons/commons-collections4
-
-	// Get release info from GitHub using API v3
-	// compile group: 'org.eclipse.mylyn.github', name: 'org.eclipse.egit.github.core', version: '4.9.0.201710071750-r' // https://mvnrepository.com/artifact/org.eclipse.mylyn.github/org.eclipse.egit.github.core
-	// compile group: 'org.kohsuke', name: 'github-api', version: '1.90' // https://mvnrepository.com/artifact/org.kohsuke/github-api
-
 
 	compile 'net.java.abeille:abeille-formsrt:2.0'
 	compile 'net.rptools.clientserver:clientserver:1.4.0.+'
@@ -194,11 +202,15 @@ dependencies {
 	compile 'de.muntjak.tinylookandfeel:tinylaf-nocp:1.4.0'
 
 	// For PDF image extraction
-	compile 'org.apache.pdfbox:pdfbox:2.0.0'
-	compile 'org.apache.pdfbox:pdfbox-tools:2.0.0'								// Dependency for pdfbox
-	compile 'org.bouncycastle:bcmail-jdk15on:1.54'								// To decrypt passworded/secured pdf's
+	compile 'org.apache.pdfbox:pdfbox:2.0.10'
+	compile 'org.bouncycastle:bcmail-jdk15on:1.59'								// To decrypt passworded/secured pdf's
 	compile 'com.github.jai-imageio:jai-imageio-core:1.4.0'						// For pdf image extraction, specifically for jpeg2000 (jpx) support.
 	compile 'com.github.jai-imageio:jai-imageio-jpeg2000:1.3.0'					// For pdf image extraction, specifically for jpeg2000 (jpx) support.
+
+	// Image processing lib
+	compile group: 'com.twelvemonkeys.imageio', name: 'imageio-core', version: '3.3.2'	// https://mvnrepository.com/artifact/com.twelvemonkeys.imageio/imageio-core
+	compile group: 'com.twelvemonkeys.imageio', name: 'imageio-jpeg', version: '3.3.2'	// https://mvnrepository.com/artifact/com.twelvemonkeys.imageio/imageio-core
+	compile group: 'com.twelvemonkeys.imageio', name: 'imageio-psd', version: '3.3.2'	// https://mvnrepository.com/artifact/com.twelvemonkeys.imageio/imageio-psd
 
 	// For syntax highlighting in macro editor
 	compile group: 'com.fifesoft', name: 'rsyntaxtextarea', version: '2.6.1'	// https://mvnrepository.com/artifact/com.fifesoft/rsyntaxtextarea
@@ -220,8 +232,6 @@ dependencies {
 	// https://mvnrepository.com/artifact/org.locationtech.jts/jts-core
 	// https://locationtech.github.io/jts/jts-features.html
 	compile group: 'org.locationtech.jts', name: 'jts-core', version: '1.15.0'
-	// https://mvnrepository.com/artifact/org.locationtech.jts/jts
-	//compile group: 'org.locationtech.jts', name: 'jts', version: '1.15.0', ext: 'pom'
 
 	// Not in use at this time, left for easy reference later...
 	//compile "com.badlogicgames.gdx:gdx-controllers:$gdxVersion"
@@ -238,18 +248,31 @@ dependencies {
 }
 
 
+task configSentryRelease(type: Copy) {
+	from("build-resources/sentry.properties.template")
+	into("src/main/resources/")
+	rename("sentry.properties.template", "sentry.properties")
+	def tokens = [
+		AppVersion: "${tagVersion}",
+		Environment: "${enviroment}",
+		SentryDSN: "${sentryDSN}"
+	]
+	expand(tokens)
+	inputs.properties(tokens)
+}
 
 task uberJar(type: Jar) {
 	group = 'distribution'
 	description = 'Create uber jar for native installers'
 
+	baseName project.name + '-' + tagVersion
+
 	manifest {
 		attributes 'Implementation-Title': project.name,
-		'Implementation-Version': version,
+		'Implementation-Version': tagVersion,
 		'Implementation-Vendor': vendor,
 		'Git-Commit': revision,
 		'Git-Commit-SHA': revisionFull,
-		// 'Git-Branch': branch,
 		'Built-By': System.getProperty('user.name'),
 		'Built-Date': new Date(),
 		'Built-JDK': System.getProperty('java.version'),
@@ -270,12 +293,11 @@ task uberJar(type: Jar) {
 // For logging Git Commit during CI
 task displayGitInfo {
 	doLast {
-		// println 'Git-Branch: ' + branch
 		println 'Git-Commit-SHA: ' + revisionFull
 	}
 }
 
-// Currently includes license, manifest (for Hdpi) and msvcr100.dll (due to packaging bug)
+// Currently includes license files
 task copyPackageExtras(type: Copy) {
 	from('package/license/')
 	into('build/libs/')
@@ -288,7 +310,7 @@ task prepareInnoSetup(type: Copy) {
 	rename("MapTool.iss.template", "MapTool.iss")
 	def tokens = [
 		AppName: "${project.name}",
-		AppVersion: "${version}",
+		AppVersion: "${tagVersion}",
 		Vendor: "${vendor}",
 		WizardImage: "${project.projectDir.absolutePath}/package/windows/${project.name}-setup.bmp",
 		Slash: "\\",
@@ -297,7 +319,7 @@ task prepareInnoSetup(type: Copy) {
 	inputs.properties(tokens)
 }
 
-task deploy(dependsOn: [displayGitInfo, uberJar, copyPackageExtras, prepareInnoSetup]) {
+task deploy(dependsOn: [clean, displayGitInfo, uberJar, copyPackageExtras, prepareInnoSetup]) {
 	group = 'distribution'
 	description = 'Create native installers'
 
@@ -319,9 +341,10 @@ task deploy(dependsOn: [displayGitInfo, uberJar, copyPackageExtras, prepareInnoS
 				"-native", "installer",
 				"-appclass", mainClassName,
 				"-srcdir", "build/libs",
-				"-outdir", "releases/release-"+version,
-				"-outfile", vendor + "-" + project.name,
+				"-outdir", "releases/release-" + tagVersion,
+				"-outfile", project.name,
 				"-name", project.name,
+				"-description", project.name + " " + tagVersion + " by " + vendor,
 				"-title", project.name,
 				"-vendor", vendor,
 				"-BdropinResourcesRoot=.",
@@ -331,14 +354,13 @@ task deploy(dependsOn: [displayGitInfo, uberJar, copyPackageExtras, prepareInnoS
 				"-BmenuHint=true",
 				"-Bwin.menuGroup=" + vendor,
 				"-BshortcutHint=true",
-				"-BappVersion=" + version,
-				"-Bwin.msi.productVersion=1.4.5",
+				"-BappVersion=" + tagVersion,
+				"-Bwin.msi.productVersion=" + msiVersion,
 				"-BlicenseFile=COPYING.AFFERO",
 				"-BlicenseType='GNU AFFERO GENERAL PUBLIC LICENSE'",
 				"-Bcategory=Games",
 				"-Bemail=maptool@nerps.net",
 				"-BuserJvmOptions=-DMAPTOOL_DATADIR\\==.maptool-" + vendor
-				// "-BjvmProperties=MAPTOOL_DATADIR=.maptool-" + vendor
 				//"-BuserJvmOptions=-Xss=4M"
 
 				println commandLine
@@ -349,3 +371,6 @@ task deploy(dependsOn: [displayGitInfo, uberJar, copyPackageExtras, prepareInnoS
 task wrapper(type: Wrapper) {
 	gradleVersion = '4.7'
 }
+
+// Configure current release tag in Sentry.io properties
+processResources.dependsOn configSentryRelease

--- a/change-log.md
+++ b/change-log.md
@@ -1,3 +1,21 @@
+MapTool 1.4.5.3 - _Infused with Nerps!_
+=====
+This is a minor bug release that fixes some annoying bugs.
+
+___
+
+Bug Fixes
+-----
+* [#80][i80] - *Comparison method violates its general contract in FogUtil.calculateVisibility(FogUtil.java:81)*. This should be fixed now.
+* [#81][i81] - *Cell Highlight distance text not sizing for grid sizes*. This is now fixed
+* [#41][i41] - *Bug Fix to allow tokens without sight to move*. Hopefully this is finally squashed properly...
+
+[i80]: https://github.com/JamzTheMan/MapTool/issues/80
+[i81]: https://github.com/JamzTheMan/MapTool/issues/81
+[i41]: https://github.com/JamzTheMan/MapTool/issues/41
+
+___
+
 MapTool 1.4.5.2 - _Infused with Nerps!_
 =====
 This is a minor enhancement release that tweaks the AI Pathfinding to produce better results in some cases.

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,10 @@
+# Change vendor RPTools for official builds, or used for things like BETA builds
+# Should change this just once for a given Repo/Fork
+vendor=Nerps
+
+# Versioning is controlled via git tag for that commit. For developing you can pass a -version=2.1 -vendor=Nerps if needed 
+tagVersion=0.0.0
+msiVersion=0.0.0
+
+sentry_development_dsn=http://dontlogme:indevelopment@localhost/1234
+sentry_production_dsn=https://96fe58677c3348bcb6127a349007b9ca:d2242adc4af146bc899db04f779a264c@sentry.io/154119

--- a/src/main/java/net/rptools/maptool/client/LaunchInstructions.java
+++ b/src/main/java/net/rptools/maptool/client/LaunchInstructions.java
@@ -11,10 +11,18 @@ package net.rptools.maptool.client;
 import javax.swing.JFrame;
 import javax.swing.JOptionPane;
 
+import org.apache.logging.log4j.ThreadContext;
+
 public class LaunchInstructions {
 	private static final String USAGE = "<html><body width=\"400\">You are running MapTool with insufficient memory allocated (%dMB).<br><br>"
 			+ "You may experience odd behavior, especially when connecting to or hosting a server.<br><br>  "
 			+ "MapTool will launch anyway, but it is recommended that you increase the maximum memory allocated or don't set a limit.</body></html>";
+
+	static {
+		// This will inject additional data tags in log4j2 which will be picked up by Sentry.io
+		System.setProperty("log4j2.isThreadContextMapInheritable", "true");
+		ThreadContext.put("OS", System.getProperty("os.name"));
+	}
 
 	public static void main(String[] args) {
 		// This is to initialize the log4j to set the path for logs. Just calling AppUtil sets the System.property

--- a/src/main/java/net/rptools/maptool/client/swing/MapToolEventQueue.java
+++ b/src/main/java/net/rptools/maptool/client/swing/MapToolEventQueue.java
@@ -82,8 +82,6 @@ public class MapToolEventQueue extends EventQueue {
 			return;
 		}
 
-		log.error("Logging stacktrace to Sentry.IO!");
-
 		// Note that all fields set on the context are optional. Context data is copied onto all future events in the
 		// current context (until the context is cleared).
 

--- a/src/main/java/net/rptools/maptool/client/tool/PointerTool.java
+++ b/src/main/java/net/rptools/maptool/client/tool/PointerTool.java
@@ -48,8 +48,6 @@ import javax.swing.ImageIcon;
 import javax.swing.JComponent;
 import javax.swing.KeyStroke;
 import javax.swing.SwingUtilities;
-import javax.swing.SwingWorker;
-
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -77,6 +75,7 @@ import net.rptools.maptool.model.GUID;
 import net.rptools.maptool.model.Grid;
 import net.rptools.maptool.model.MovementKey;
 import net.rptools.maptool.model.Player;
+import net.rptools.maptool.model.Player.Role;
 import net.rptools.maptool.model.Pointer;
 import net.rptools.maptool.model.Token;
 import net.rptools.maptool.model.TokenFootprint;
@@ -873,13 +872,13 @@ public class PointerTool extends DefaultTool implements ZoneOverlay {
 				// Rolled back change from commit 3d5f619 because of reported bug by dorpond
 				// https://github.com/JamzTheMan/maptool/commit/3d5f619dff6e61c605ee532ac3c86a3860e91864
 				if (useTokenExposedArea) {
-					// if (token.getHasSight()) {
 					ExposedAreaMetaData meta = zone.getExposedAreaMetaData(token.getExposedAreaGUID());
 					tokenFog.add(meta.getExposedAreaHistory());
-					// } else {
-					// // Jamz: Allow a token without site to move within the current PlayerView
-					// tokenFog.add(renderer.getZoneView().getVisibleArea(new PlayerView(Role.PLAYER)));
-					// }
+
+					// Jamz: Allow a token without site to move within the current PlayerView
+					if (!token.getHasSight()) {
+						tokenFog.add(renderer.getZoneView().getVisibleArea(new PlayerView(Role.PLAYER)));
+					}
 				}
 
 				Rectangle tokenSize = token.getBounds(zone);

--- a/src/main/java/net/rptools/maptool/client/ui/zone/ZoneRenderer.java
+++ b/src/main/java/net/rptools/maptool/client/ui/zone/ZoneRenderer.java
@@ -2259,7 +2259,6 @@ public class ZoneRenderer extends JComponent implements DropTargetListener, Comp
 				zp.x += grid.getCellWidth() / 2 + cellOffset.width;
 				zp.y += grid.getCellHeight() / 2 + cellOffset.height;
 				addDistanceText(g, zp, 1.0f, p.getDistanceTraveled(zone));
-				// log.info("p.getDistanceTraveled(zone): " + p.getDistanceTraveled(zone));
 			}
 			int w = 0;
 			for (ZonePoint p : waypointList) {
@@ -2520,8 +2519,9 @@ public class ZoneRenderer extends JComponent implements DropTargetListener, Comp
 		int cellY = (int) (sp.y - iheight / 2);
 
 		// Draw distance for each cell
-		int fontSize = (int) (getScale() * 12);
-		int textOffset = (int) (getScale() * 7); // 7 pixels at 100% zoom
+		double fontScale = (double) grid.getSize() / 50; // Font size of 12 at grid size 50 is default
+		int fontSize = (int) (getScale() * 12 * fontScale);
+		int textOffset = (int) (getScale() * 7 * fontScale); // 7 pixels at 100% zoom & grid size of 50
 
 		Font font = new Font(Font.DIALOG, Font.BOLD, fontSize);
 		Font originalFont = g.getFont();
@@ -2532,7 +2532,7 @@ public class ZoneRenderer extends JComponent implements DropTargetListener, Comp
 		g.setFont(font);
 		g.setColor(Color.BLACK);
 
-		// log.info("Text: [" + distanceText + "], width: " + textWidth + ", font size: " + fontSize + ", offset: " + textOffset);
+		// log.info("Text: [" + distanceText + "], width: " + textWidth + ", font size: " + fontSize + ", offset: " + textOffset + ", fontScale: " + fontScale+ ", getScale(): " + getScale());
 
 		g.drawString(distanceText, (int) (cellX + cwidth - textWidth - textOffset), (int) (cellY + cheight - textOffset));
 		g.setFont(originalFont);

--- a/src/main/java/net/rptools/maptool/client/ui/zone/vbl/VisibleAreaSegment.java
+++ b/src/main/java/net/rptools/maptool/client/ui/zone/vbl/VisibleAreaSegment.java
@@ -43,10 +43,6 @@ public class VisibleAreaSegment implements Comparable<VisibleAreaSegment> {
 		return (long) (getCenterPoint().distance(origin) * 1000);
 	}
 
-	public double getDoubleDistanceFromOrigin() {
-		return getCenterPoint().distance(origin);
-	}
-
 	public Point2D getCenterPoint() {
 		if (centerPoint == null) {
 			Area path = getPath();
@@ -122,7 +118,7 @@ public class VisibleAreaSegment implements Comparable<VisibleAreaSegment> {
 			// So we changed getDistanceFromOrigin() to return a long after multiplying by 1000 for precision
 			long odist = o.getDistanceFromOrigin();
 			long val = getDistanceFromOrigin() - odist; // separate variable for debugging
-			return (int) (getDoubleDistanceFromOrigin() - o.getDoubleDistanceFromOrigin());
+			return (int) val;
 			// return val < EPSILON && val > -EPSILON ? 0 : (int) val; // Should we use an EPSILON value?
 			// return getDistanceFromOrigin() < odist ? -1 : getDistanceFromOrigin() > odist ? 1 : 0;
 		}

--- a/src/main/resources/log4j2.xml
+++ b/src/main/resources/log4j2.xml
@@ -9,8 +9,8 @@
 		</File>
 	</Appenders>
 	<Loggers>
-		<Root level="info">
-			<AppenderRef ref="Console" />
+		<Root level="INFO">
+			<AppenderRef ref="Console" level="DEBUG" />
 			<AppenderRef ref="LogFile" />
 		</Root>
 	</Loggers>

--- a/src/main/resources/sentry.properties
+++ b/src/main/resources/sentry.properties
@@ -1,3 +1,4 @@
-dsn=https://96fe58677c3348bcb6127a349007b9ca:d2242adc4af146bc899db04f779a264c@sentry.io/154119
-environment=Production
+dsn=http://dontlogme:indevelopment@localhost/1234
+environment=Development
 stacktrace.app.packages=net.rptools.lib,net.rptools.maptool
+release=SNAPSHOT-599398f


### PR DESCRIPTION
* #77: Drag path does not seem to be working correctly.

	* Tweaked the A* algorithm for more natural/straighter moves though
open spaces for both square and hex grids
	* Tweaked the A* algorithm to find shortest path more consistently

Task-Url: https://github.com/JamzTheMan/maptool/issues/77

Signed-off-by: Jamz <Jamz@Nerps.net>

* #77: Drag path does not seem to be working correctly.

 * Change log amended
 * Spotless applied

Task-Url: https://github.com/JamzTheMan/maptool/issues/77

Signed-off-by: Jamz <Jamz@Nerps.net>

* Minor update to PDF Extract

 * Updated PDFBox lib to latest
 * Sync'd PDF extract code from TokenTool (similiar but not 100% same on
purpose)

Signed-off-by: Jamz <Jamz@Nerps.net>

* #80 Comparison method violates its general contract in...

 * Reverting VisibleAreaSegment to previous version...

Signed-off-by: Jamz <Jamz@Nerps.net>

* #81: Cell Highlight distance text not sizing for grid sizes

 * Cell Highlight distance text now properly scales with grid size
 * Adjusted logging slightly

Task-Url: https://github.com/JamzTheMan/maptool/issues/81

Signed-off-by: Jamz <Jamz@Nerps.net>

* CI Updates

* CI Updates

* CI Updates

* CI Updates

* Gradle Process Updated

 * Vendor property now comes from gradle.properties
 * Version now comes from Git, uses SNAPSHOT-{commit} for
development/non-tagged releases and uses Tag name if commit is tagged
 * Updated Apache logging versions
 * sentry.properties file now generated, DSN is now only configured for
tagged releases, eg Production. This prevents sentry logging during
development

Signed-off-by: Jamz <Jamz@Nerps.net>

* #41: Bug Fix to allow tokens without sight to move

 * Tokens without sight can move within current PC tokens field of view
when iFoW server options are checked
 * Tweaked sentry.properties to use dummy DSN when in development mode

Task-Url: https://github.com/JamzTheMan/maptool/issues/41

Signed-off-by: Jamz <Jamz@Nerps.net>